### PR TITLE
Send CryptKey instance to oauth2 with new permission check disabled

### DIFF
--- a/src/JwtClaimsServiceProvider.php
+++ b/src/JwtClaimsServiceProvider.php
@@ -8,6 +8,7 @@ use Laravel\Passport\Bridge\ScopeRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
 
+
 class JwtClaimsServiceProvider extends PassportServiceProvider
 {
 
@@ -32,7 +33,7 @@ class JwtClaimsServiceProvider extends PassportServiceProvider
             $this->app->make(AccessTokenRepository::class), // BenBjurstrom\JwtClaims\AccessTokenRepository
             $this->app->make(ScopeRepository::class),
             new CryptKey( 'file://'.Passport::keyPath('oauth-private.key'), null, false ),
-            new CryptKey('file://'.Passport::keyPath('oauth-public.key'), null, false )
+            app('encrypter')->getKey()
         );
     }
 

--- a/src/JwtClaimsServiceProvider.php
+++ b/src/JwtClaimsServiceProvider.php
@@ -6,6 +6,7 @@ use Laravel\Passport\PassportServiceProvider;
 use Laravel\Passport\Bridge\ClientRepository;
 use Laravel\Passport\Bridge\ScopeRepository;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\CryptKey;
 
 class JwtClaimsServiceProvider extends PassportServiceProvider
 {
@@ -30,8 +31,8 @@ class JwtClaimsServiceProvider extends PassportServiceProvider
             $this->app->make(ClientRepository::class),
             $this->app->make(AccessTokenRepository::class), // BenBjurstrom\JwtClaims\AccessTokenRepository
             $this->app->make(ScopeRepository::class),
-            'file://'.Passport::keyPath('oauth-private.key'),
-            'file://'.Passport::keyPath('oauth-public.key')
+            new CryptKey( 'file://'.Passport::keyPath('oauth-private.key'), null, false ),
+            new CryptKey('file://'.Passport::keyPath('oauth-public.key'), null, false )
         );
     }
 


### PR DESCRIPTION
When running in some development environments, eg Vagrant on Windows (or most other methods you might use to develop in windows, eg docker or a local PHP install)  it's impossible to make the oauth-private.key file match the exact permissions that  thephpleague/oauth2-server now checks for, and this means everything will fail with an exception

Passport fixed this in this PR https://github.com/laravel/passport/pull/454 and this code implements a similar solution in  benbjurstrom/passport-custom-jwt-claims
